### PR TITLE
Fix mediciones modal

### DIFF
--- a/Repo BDPA/js/maquetacion.html
+++ b/Repo BDPA/js/maquetacion.html
@@ -685,8 +685,11 @@ function actualizarConfiguracionRed() {
 
 // Abrir modal de registro de mediciones (función placeholder)
 function abrirModalRegistroMediciones() {
-    alert('Esta función abrirá el modal independiente de Registro de Mediciones que generará una hoja de cálculo separada.');
-    // En la implementación real, aquí se abriría el modal específico de mediciones
+    if (typeof mostrarModalMediciones === 'function') {
+        mostrarModalMediciones();
+    } else {
+        alert('Esta función abrirá el modal independiente de Registro de Mediciones que generará una hoja de cálculo separada.');
+    }
 }
 
 // ============================================================================

--- a/Repo BDPA/js/mediciones.html
+++ b/Repo BDPA/js/mediciones.html
@@ -94,6 +94,51 @@ async function cargarEstructuraMedicion() {
     }
 }
 
+// ---------------------------------------------------------------
+// Funciones para los select dependientes del modal antiguo
+// ---------------------------------------------------------------
+
+function cargarTorresMedicion() {
+    // Reutiliza la carga de estructura para poblar las torres
+    cargarEstructuraMedicion();
+}
+
+function cargarPisosMedicion() {
+    const torreId = document.getElementById('medicion-torre').value;
+    const selectPiso = document.getElementById('medicion-piso');
+    if (!selectPiso || !torreId) return;
+
+    selectPiso.innerHTML = '<option value="">Seleccionar piso...</option>';
+    const torre = estructuraEdificio.torres?.find(t => t.id === torreId);
+    if (torre) {
+        torre.pisos.forEach(piso => {
+            const opt = document.createElement('option');
+            opt.value = piso.id;
+            opt.textContent = piso.numero;
+            selectPiso.appendChild(opt);
+        });
+    }
+}
+
+function cargarUnidadesMedicion() {
+    const torreId = document.getElementById('medicion-torre').value;
+    const pisoId = document.getElementById('medicion-piso').value;
+    const selectUnidad = document.getElementById('medicion-unidad');
+    if (!selectUnidad) return;
+
+    selectUnidad.innerHTML = '<option value="">Seleccionar unidad...</option>';
+    const torre = estructuraEdificio.torres?.find(t => t.id === torreId);
+    const piso = torre?.pisos.find(p => p.id === pisoId);
+    if (piso) {
+        piso.departamentos.forEach(depto => {
+            const opt = document.createElement('option');
+            opt.value = depto.id;
+            opt.textContent = depto.numero;
+            selectUnidad.appendChild(opt);
+        });
+    }
+}
+
 // Cambiar tipo de medición
 function cambiarTipoMedicion() {
     const tipo = document.getElementById('medicion-tipo-senal').value;
@@ -540,4 +585,4 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 console.log('[MEDICIONES] Archivo js/mediciones.html cargado completamente');
-</script
+</script>


### PR DESCRIPTION
## Summary
- add missing `</script>` and helper functions to mediciones script
- make maquetacion open mediciones modal if available

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685e7feb8450832f96297067fc996a88